### PR TITLE
Fix bootstrap.sh with newer bundler

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,10 +45,10 @@ then
   gem install bundler
 
   # Setup
-  sudo -u vagrant bundle
-  sudo -u vagrant bundle exec rake db:create db:migrate
-  sudo -u vagrant bundle exec rake db:create db:migrate RAILS_ENV=test
-  sudo -u vagrant bundle exec rspec
+  sudo su - vagrant -c "cd ~/meppit && bundle"
+  sudo su - vagrant -c "cd ~/meppit && bundle exec rake db:create db:migrate"
+  sudo su - vagrant -c "cd ~/meppit && bundle exec rake db:create db:migrate RAILS_ENV=test"
+  sudo su - vagrant -c "cd ~/meppit && bundle exec rspec"
 
   touch ~/runonce
 fi


### PR DESCRIPTION
This will avoid error:

``` bash
==> default: /usr/lib/ruby/2.0.0/fileutils.rb:245:in `mkdir'
==> default: : 
==> default: Permission denied - /root/.bundler
==> default:  (
==> default: Errno::EACCES
==> default: )
==> default:    from /usr/lib/ruby/2.0.0/fileutils.rb:245:in `fu_mkdir'
```
